### PR TITLE
Support for Arduino Pro Mini on Bot Board

### DIFF
--- a/BotBoarduino_CH3R_PS2.ino
+++ b/BotBoarduino_CH3R_PS2.ino
@@ -9,6 +9,8 @@
 // This version of the Phoenix code was ported over to the Arduino Environement
 // and is specifically configured for the Lynxmotion BotBoarduino 
 //
+//NEW IN V2.1 (2013-05-17)
+//   - setup() made more generic by replacing exact pin-n° by PS2_CMD
 //NEW IN V2.X
 //=============================================================================
 //
@@ -304,8 +306,8 @@ void setup(){
     // Init our ServoDriver
     g_ServoDriver.Init();
     
-    pinMode(7, INPUT);
-    if(!digitalRead(7))
+    pinMode(PS2_CMD, INPUT);
+    if(!digitalRead(PS2_CMD))
       g_ServoDriver.SSCForwarder();
 
    //Checks to see if our Servo Driver support a GP Player

--- a/Hex_Cfg.h
+++ b/Hex_Cfg.h
@@ -13,16 +13,27 @@
 //Date: March 18, 2012
 //Programmer: Kurt (aka KurtE)
 //
-//
+//NEW IN V1.1 (2013-05-17)
+//   - Support for Arduino Pro Mini on Bot Board (originally for Basic Atom Pro)
 //NEW IN V1.0
 //   - First Release
 //
 //====================================================================
 
+//==================================================================================================================================
+//==================================================================================================================================
+//==================================================================================================================================
 //[CONDITIONAL COMPILING] - COMMENT IF NOT WANTED
 // Define other optional compnents to be included or not...
+
+//comment if terminal monitor is not required
 #define OPT_TERMINAL_MONITOR  
 
+//uncomment the board you want to use
+//#define __BOTBOARDUINO__    //botboarduino board
+#define __BOTBOARD_ARDUINOPROMINI__  //arduino pro mini on botboard (originally for BasicAtomPro)
+
+//====================================================================
 #ifdef OPT_TERMINAL_MONITOR   // turning off terminal monitor will turn these off as well...
 #define OPT_SSC_FORWARDER  // only useful if terminal monitor is enabled
 #define OPT_FIND_SERVO_OFFSETS    // Only useful if terminal monitor is enabled
@@ -50,25 +61,40 @@
 
 //[SERIAL CONNECTIONS]
 
-
 // Warning I will undefine some components as the non-megas don't have enough memory...
 //#undef OPT_FIND_SERVO_OFFSETS 
 
-#define cSSC_BAUD        38400   //SSC32 BAUD rate
+#define cSSC_BAUD   38400   //SSC32 BAUD rate
 
 //--------------------------------------------------------------------
 //[Botboarduino Pin Numbers]
-#define SOUND_PIN    5        // Botboarduino JR pin number
-#define PS2_DAT      6        
-#define PS2_CMD      7
-#define PS2_SEL      8
-#define PS2_CLK      9
+#ifdef __BOTBOARDUINO__
+  #define SOUND_PIN       5   // Botboarduino JR pin number
+  #define PS2_DAT         6        
+  #define PS2_CMD         7
+  #define PS2_SEL         8
+  #define PS2_CLK         9
 // If we are using a SSC-32 then:
 // If were are running on an Arduino Mega we will use one of the hardware serial port, default to Serial1 above.
 // If on Non mega, if the IO pins are set to 0, we will overload the hardware Serial port 
 // Else we will user SoftwareSerial to talk to the SSC-32
-#define cSSC_OUT     12      	//Output pin for (SSC32 RX) on BotBoard (Yellow)
-#define cSSC_IN      13      	//Input pin for (SSC32 TX) on BotBoard (Blue)
+  #define cSSC_OUT       12   //Output pin for Botboard - Input of SSC32 (Yellow)
+  #define cSSC_IN        13   //Input pin for Botboard - Output of SSC32 (Blue)
+#endif
+
+#ifdef __BOTBOARD_ARDUINOPROMINI__
+  #define SOUND_PIN      11   // Bot Board JR pin number (with Arduino Pro Mini plugged)
+  #define PS2_DAT        14       
+  #define PS2_CMD        15
+  #define PS2_SEL        16
+  #define PS2_CLK        17
+// If we are using a SSC-32 then:
+// If were are running on an Arduino Mega we will use one of the hardware serial port, default to Serial1 above.
+// If on Non mega, if the IO pins are set to 0, we will overload the hardware Serial port 
+// Else we will user SoftwareSerial to talk to the SSC-32
+  #define cSSC_OUT       10   //Output pin for Botboard - Input of SSC32 (Yellow)
+  #define cSSC_IN         9   //Input pin for Botboard - Output of SSC32 (Blue)
+#endif
 
 //====================================================================
 //[SSC PIN NUMBERS]

--- a/phoenix_driver_ssc32.cpp
+++ b/phoenix_driver_ssc32.cpp
@@ -302,7 +302,7 @@ void  ServoDriver::SSCForwarder(void)
     int sPrevChar;
     DBGSerial.println("SSC Forwarder mode - Enter $<cr> to exit");
     
-    while(digitalRead(7)) {
+    while(digitalRead(PS2_CMD)) {
         if ((sChar = DBGSerial.read()) != -1) {
             SSCSerial.write(sChar & 0xff);
             if (((sChar == '\n') || (sChar == '\r')) && (sPrevChar == '$'))


### PR DESCRIPTION
- support for Arduino Pro Mini on Bot Board (originally for Basic Atom
  Pro)
- setup() made generic (replaced fixed pin-n°)
